### PR TITLE
Update README.md to include Deno setup and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,20 @@ JavaScript code, how to trigger react to callbacks, get and set properties and u
 
 In order to use this template and build a Node.js application, you need to install a few tools:
 
-  * **[Node.js](https://nodejs.org/download/release/)** (v16. or newer)
-  * **[npm](https://www.npmjs.com/)**
   * **[Rust compiler](https://www.rust-lang.org/tools/install)** (1.70 or newer)
 
+If you use Node.js:
+
+  * **[Node.js](https://nodejs.org/download/release/)** (v16. or newer)
+  * **[npm](https://www.npmjs.com/)**
+
+If you use Deno:
+
+  * **[Deno](https://deno.com/)**
+
 ## Usage
+
+### Using Node.js
 
 1. Clone or download this repository
     ```
@@ -31,6 +40,20 @@ In order to use this template and build a Node.js application, you need to insta
     ```
     npm start
     ```
+
+### Using Deno
+
+1. Clone or download this repository
+    ```
+    git clone https://github.com/slint-ui/slint-nodejs-template my-project
+    cd my-project
+    ```
+2. Run the application binary
+    ```
+    deno run --allow-read --allow-ffi src/main.js
+    ```
+
+### Additional information
 
 We recommend using an IDE for development, along with our [LSP-based IDE integration for `.slint` files](https://github.com/slint-ui/slint/blob/master/tools/lsp/README.md). You can also load this project directly in [Visual Studio Code](https://code.visualstudio.com) and install our [Slint extension](https://marketplace.visualstudio.com/items?itemName=Slint.slint).
 


### PR DESCRIPTION
This commit updates the README.md to add setup and usage instructions for Deno alongside existing instructions for Node.js. It improves the document structure by separating the usage sections for Node.js and Deno, ensuring clarity and easy navigation for users working with different environments.

- Adds a new section detailing the requirements and setup for Deno.
- Revises the existing sections to accommodate the inclusion of Deno, maintaining a clear and organized layout.
- Enhances the document's readability by appropriately spacing and titling each section.